### PR TITLE
changed header size per linter recs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # authentic-grace
+
 Authentic Grace website development repository. A collaboration project between Nancy Melendez, Erica Forget, and Sara McCombs.
 
-# Photography Credits
+## Photography Credits
 
 * [Tommy White Photography](https://www.tommywhitephotography.com/Portfolio/Landscapes/i-x82n6GL/A)
 
-# Site Color Palette
+## Site Color Palette
 
-# Site Font Selections
+## Site Font Selections
 
 * Header graphic font: [Miss Farjadose](https://fonts.google.com/specimen/Miss+Fajardose)
 * Body font: [Lato](https://fonts.google.com/specimen/Lato)


### PR DESCRIPTION
linter recommended only one top-level heading on a page to prevent errors with page parsers. Changed most headings to the next level down to correct this error. Forgot to include this in the previous pull request. 